### PR TITLE
Enhance broker to provide more information to apps

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -284,12 +284,16 @@ func (b *Broker) Bind(instance, bindingID string, details brokerapi.BindDetails)
 		"username": user,
 		"password": pass,
 		"database": db,
+		"jdbcUrl":  fmt.Sprintf("jdbc:mysql://%s:%s/%s?user=%s&password=%s&useSSL=false", b.Host, b.Port, db, user, pass),
+		"name":     db,
 		"host":     b.Host,
+		"hostname": b.Host,
 		"port":     b.Port,
 		"dsn":      fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, pass, b.Host, b.Port, db),
+		"uri":      fmt.Sprintf("mysql://%s:%s@%s:%s/%s", user, pass, b.Host, b.Port, db),
 	}
 
-	info("bound %s:%s@tcp(%s:%s)/%s\n", user, pass, b.Host, b.Port, db)
+	info("bound mysql://%s:%s@%s:%s/%s\n", user, pass, b.Host, b.Port, db)
 	info("creds = %v\n", binding.Credentials)
 	return binding, nil
 }

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	broker.Plan.ID = cfg("mariadb-43e22be8-5a3a-496c-b502-02079483f6dd", "PLAN_ID")
 	broker.Plan.Name = cfg("shared", "PLAN_NAME")
 	broker.Description = cfg("A shared MariaDB database", "DESCRIPTION")
-	broker.Tags = strings.Split(cfg("shared,mariadb,tinsmith", "TAGS"), ",")
+	broker.Tags = strings.Split(cfg("shared,mariadb,tinsmith,mysql", "TAGS"), ",")
 
 	app, err := vcaptive.ParseApplication(os.Getenv("VCAP_APPLICATION"))
 	if err != nil {


### PR DESCRIPTION
What:
- provide extra elements inside the credentials block
- tag as mysql too

Why:
- some apps can't use DSNs if they use ancient libraries
- tag as mysql so Java apps that use spring can work out what flavour of service it is